### PR TITLE
Add check for S < L as in RFC 8032

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,0 +1,26 @@
+name: PR Builder
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+  workflow_dispatch:
+
+env:
+  MAVEN_OPTS: -Xmx4g -Xms1g
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: "temurin"
+          cache: 'maven'
+      - name: Build with Maven
+        run: mvn clean install -U -B

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>net.i2p.crypto</groupId>
-  <artifactId>eddsa</artifactId>
-  <version>0.3.0</version>
-  <name>EdDSA-Java</name>
+
+  <parent>
+    <groupId>org.wso2</groupId>
+    <artifactId>wso2</artifactId>
+    <version>1.4</version>
+  </parent>
+
+  <groupId>org.wso2.crypto.eddsa</groupId>
+  <artifactId>wso2-eddsa</artifactId>
+  <version>0.3.0.wso2v1-SNAPSHOT</version>
   <packaging>bundle</packaging>
-  <description>Implementation of EdDSA in Java</description>
-  <url>https://github.com/str4d/ed25519-java</url>
+  <name>WSO2 EdDSA-Java</name>
+  <description>WSO2 fork of EdDSA Java implementation with additional fixes</description>
+  <url>https://github.com/wso2/wso2-ed25519-java</url>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -26,16 +34,19 @@
     </developer>
   </developers>
   <scm>
-    <connection>scm:git:git://github.com/str4d/ed25519-java.git</connection>
-    <developerConnection>scm:git:git@github.com:str4d/ed25519-java.git</developerConnection>
-    <url>https://github.com/str4d/ed25519-java</url>
+    <connection>scm:git:git://github.com/wso2/wso2-ed25519-java.git</connection>
+    <developerConnection>scm:git:git@github.com:wso2/wso2-ed25519-java.git</developerConnection>
+    <url>https://github.com/wso2/wso2-ed25519-java</url>
   </scm>
+
   <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
+    <repository>
+      <id>nexus-releases</id>
+      <name>WSO2 Release Distribution Repository</name>
+      <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
+
   <build>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
@@ -52,8 +63,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
         <version>3.8.0</version>
@@ -128,26 +139,21 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
         <version>1.6</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <preparationGoals>clean install</preparationGoals>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
@@ -161,8 +167,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <type>maven-plugin</type>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request updates the project to align with WSO2 standards and addresses a security compliance issue in the EdDSA signature verification logic.

**Security and compliance improvement:**

* Added a check in `EdDSAEngine.java` to ensure the S component of Ed25519 signatures is less than the group order, preventing acceptance of invalid signatures as per the specification. [[1]](diffhunk://#diff-e7bd2a6d5dfcaacb5e4f26a51d8f2bceec9df2564a991d4c6d6836c53f52249dR90-R92) [[2]](diffhunk://#diff-e7bd2a6d5dfcaacb5e4f26a51d8f2bceec9df2564a991d4c6d6836c53f52249dR313-R323)
* Imported `BigIntegerLittleEndianEncoding` and `BigInteger` to support the new signature validation logic. [[1]](diffhunk://#diff-e7bd2a6d5dfcaacb5e4f26a51d8f2bceec9df2564a991d4c6d6836c53f52249dR15) [[2]](diffhunk://#diff-e7bd2a6d5dfcaacb5e4f26a51d8f2bceec9df2564a991d4c6d6836c53f52249dR33)

**Project metadata and build configuration updates:**

* Updated `pom.xml` to set WSO2 as the parent project, changed the group/artifact IDs and project name/description, and pointed SCM and distribution management to WSO2 repositories. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L4-R18) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L29-R49)
* Updated the Maven compiler plugin to target Java 1.8 instead of 1.7, and upgraded the JUnit test dependency to version 4.13.2. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L55-R67) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L164-R170)
* Replaced Sonatype Nexus plugins with WSO2 release and deploy plugins, disabled GPG signing, and removed Nexus staging configuration.

Related Issue - https://github.com/str4d/ed25519-java/issues/82
Related PR - https://github.com/i2p/i2p.i2p/commit/d7d1dcb5399c61cf2916ccc45aa25b0209c88712